### PR TITLE
Move `_start/_endTime` in `ScavengerStats` to `Collector`.

### DIFF
--- a/runtime/gc_trace/TgcParallel.cpp
+++ b/runtime/gc_trace/TgcParallel.cpp
@@ -32,6 +32,7 @@
 #endif /* J9VM_GC_VLHGC */
 #include "EnvironmentVLHGC.hpp"
 #include "GCExtensions.hpp"
+#include "Scavenger.hpp"
 #include "TgcExtensions.hpp"
 #include "VMThreadListIterator.hpp"
 
@@ -258,7 +259,7 @@ tgcHookLocalGcEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData, v
 	tgcExtensions->printf("          gc thrID     busy    stall   acquire   release   acquire   release   acquire     split avg split  alias to    deep      total deepest\n");
 	tgcExtensions->printf("                   (micros) (micros)  freelist  freelist  scanlist  scanlist      lock    arrays arraysize copycache   lists  deep objs    list\n");
 
-	scavengeTotalTime = extensions->scavengerStats._endTime - extensions->scavengerStats._startTime;
+	scavengeTotalTime = extensions->scavenger->_cycleEndTime - extensions->scavenger->_cycleStartTime;
 	uintptr_t gcCount = extensions->scavengerStats._gcCount;
 
 	GC_VMThreadListIterator scavengeThreadListIterator(vmThread);


### PR DESCRIPTION
This is OpenJ9 side of https://github.com/eclipse/omr/pull/6068
Retrieve `_start/endTime` from `Scavenger` instead of `ScavengerStats`
